### PR TITLE
Add .gitattributes with export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/tests              export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.codacy.yml        export-ignore
+/.travis.yml        export-ignore
+/codesize.xml       export-ignore
+/phpunit.xml        export-ignore

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ and include the composer's autoloader in your code
 include 'vendor/autoload.php';
 ```
 
-
 ## Usage
 
 ### Simple usage

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "enricodias/nameize",
     "type": "library",
     "license": "MIT",
-    "description": "A simple class to correctly capitalize full names, specially Brazilian names.",
+    "description": "A simple class to correctly capitalize full names.",
     "keywords": ["name", "formater", "format"],
     "authors": [
         {
@@ -21,7 +21,6 @@
     },
     "require-dev": {
         "codacy/coverage": "^1.4",
-        "phpmd/phpmd": "^2.7",
         "phpunit/phpunit": ">5.7 <9"
     }
 }

--- a/src/Nameize.php
+++ b/src/Nameize.php
@@ -3,8 +3,7 @@
 namespace enricodias;
 
 class Nameize
-{
-	
+{	
 	private $_minLength = 4;
 	private $_allowedCharacters = array(' ', "'", '-');
 	


### PR DESCRIPTION
Add `.gitattributes` with `export-ignore` to exclude test files form production environments.
Remove `phpmd/phpmd` dependency as Codacy already uses it.
Update package description.